### PR TITLE
Fix typos, URL's and HTML iframe syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Open an `incognito` window from your browser and copy the URL (`http://localhost
 
 **SESSION 1**
 
-+ [ressources and acknowledgments](https://cdn.rawgit.com/nicolasfauchereau/Python-for-data-analysis-and-visualisation/master/session_1/notebooks/ressources.html)
++ [resources and acknowledgments](https://cdn.rawgit.com/nicolasfauchereau/Python-for-data-analysis-and-visualisation/master/session_1/notebooks/resources.html)
 
 + [IPython notebook
   overview](https://cdn.rawgit.com/nicolasfauchereau/Python-for-data-analysis-and-visualisation/master/session_1/notebooks/IPython_notebook.html)

--- a/session_1/notebooks/IPython_notebook.ipynb
+++ b/session_1/notebooks/IPython_notebook.ipynb
@@ -81,6 +81,7 @@
    },
    "outputs": [],
    "source": [
+    "from IPython.display import HTML\n",
     "HTML('<iframe src=http://ipython.org/notebook.html width=900 height=350></iframe>')"
    ]
   },
@@ -130,6 +131,7 @@
    },
    "outputs": [],
    "source": [
+    "from IPython.display import HTML\n",
     "HTML('<iframe src=http://www.nature.com/news/interactive-notebooks-sharing-the-code-1.16261 width=900 height=350></iframe>')"
    ]
   },
@@ -434,7 +436,7 @@
    },
    "outputs": [],
    "source": [
-    "from IPython.display import Image, YouTubeVideo"
+    "from IPython.display import Image, YouTubeVideo, HTML"
    ]
   },
   {
@@ -447,6 +449,7 @@
    "source": [
     "### that will display a frame with specified width and height ... \n",
     "\n",
+    "from IPython.display import HTML\n",
     "HTML('<iframe src=\"http://numpy.org/\" height=300 width=800>'\n",
     "     '</iframe>')"
    ]
@@ -961,6 +964,7 @@
    },
    "outputs": [],
    "source": [
+    "from IPython.display import HTML\n",
     "display(HTML(\"<a href='{name}.html' target='_blank'> {name}.html </a>\".format(name=name)))"
    ]
   },

--- a/session_1/notebooks/resources.html
+++ b/session_1/notebooks/resources.html
@@ -3,7 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
-<title>ressources</title>
+<title>resources</title>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
@@ -110,44 +110,6 @@
 .highlight .vg { color: #19177C } /* Name.Variable.Global */
 .highlight .vi { color: #19177C } /* Name.Variable.Instance */
 .highlight .il { color: #666666 } /* Literal.Number.Integer.Long */
-    </style>
-<style type="text/css">
-    /* for presentations
-
-div#menubar-container {
-  width: 100%;
-}
-div#menubar div.navbar {
-  margin-bottom: 0px;
-}
-
-div#notebook_panel {
-  -moz-box-shadow: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-}
-
-div#notebook {
-  font-size: 22px;
-  line-height: 1.25em;
-  border-top: 0px;
-  pre {
-    line-height: 1.125em;
-  }
-}
-
-.rendered_html li {
-  line-height: 1.25em;
-}
-
-/* the real stuff */
-
-/* disable pager
-  only use this if you have also disabled the pager in Python,
-  (`%load_ext print_page` from github.com/minrk/ipython_extensions)
-  or never use ? or ??
-*/
-
     </style>
 
 
@@ -316,7 +278,7 @@ h1.title {
 </div>
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
-<h1 id="ressources">ressources<a class="anchor-link" href="#ressources">&#182;</a></h1>
+<h1 id="resources">resources<a class="anchor-link" href="#resources">&#182;</a></h1>
 </div>
 </div>
 </div>
@@ -425,7 +387,7 @@ $(function() {
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <ul>
-<li><a href="www.google.com">www.google.com</a></li>
+<li><a href="http://www.google.com">www.google.com</a></li>
 <li><a href="http://www.freenetpages.co.uk/hp/alan.gauld/tutclass.htm">A good tutorial by Alan Gauld</a></li>
 <li>The <a href="http://docs.python.org/2/tutorial/classes.html">classes</a> entry from the official Python doc </li>
 <li>A short <a href="http://www1.gly.bris.ac.uk/~walker/PythonEarthSci/PfES_3.pdf">pdf</a> from Andrew Walker's <a href="http://www1.gly.bris.ac.uk/~walker/PythonEarthSci/">Python for Earth Scientists</a> course</li>
@@ -597,7 +559,7 @@ $(function() {
 <li><a href="https://github.com/barbagroup/CFDPython">github repository for the above</a></li>
 <li><a href="http://openfoamwiki.net/index.php/Contrib_PyFoam">Python bindings to OpenFOAM</a></li>
 <li><a href="http://matforge.org/fipy/">FiPy: A Finite Volume PDE Solver Using Python</a></li>
-<li><a href="">"Practical Numerical Methods with Python" MOOC</a></li>
+<li><a href="http://openedx.seas.gwu.edu/courses/GW/MAE6286/2014_fall/about">"Practical Numerical Methods with Python" MOOC</a></li>
 </ul>
 
 </div>
@@ -746,7 +708,7 @@ $(function() {
 <li><p><a href="https://github.com/ipython/ipython/wiki/A-gallery-of-interesting-IPython-Notebooks">A gallery of interesting IPython Notebooks</a>
 "...a curated collection of IPython notebooks that are notable for some reason."</p>
 </li>
-<li><p><a href="https://github.com/jakevdp/sklearn_scipy2013">Scikit-learn tutorial</a>: Files and other info associated with the Scipy 2013 scikit-learn tutorial developped by Gaël Varoquaux, Olivier Grisel and Jake VanderPlas.</p>
+<li><p><a href="https://github.com/jakevdp/sklearn_scipy2013">Scikit-learn tutorial</a>: Files and other info associated with the Scipy 2013 scikit-learn tutorial developed by Gaël Varoquaux, Olivier Grisel and Jake VanderPlas.</p>
 </li>
 <li><p><a href="https://github.com/fonnesbeck/statistical-analysis-python-tutorial">Statistical Analysis tutorial</a> from Chris. Fonnesbeck.</p>
 </li>
@@ -885,20 +847,20 @@ $(function() {
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>In building this material, I have liberally '<em>borrowed</em>' from lecture notes, online notebooks, video recording of talks, code examples, articles, etc, that are freely available online, I would like to acknowledge in particular (list not exhaustive and in no particular order):</p>
 <ul>
-<li><a href="http://blog.fperez.org">Fernando Perez</a>: Lead developper of <a href="www.ipython.org">IPython</a>, great advocate of <a href="http://en.wikipedia.org/wiki/Open_science">open science</a> and reproducible research</li>
-<li>Brian Granger: Lead developper of the <a href="http://ipython.org/notebook.html">IPython notebook</a></li>
-<li><a href="http://blog.wesmckinney.com">Wes McKinney</a>: Lead developper of Pandas, author of <a href="http://shop.oreilly.com/product/0636920023784.do">Python for Data Analysis</a></li>
-<li><a href="http://biostat.mc.vanderbilt.edu/wiki/Main/ChrisFonnesbeck">Christopher Fonnesbeck</a>: Developper of <a href="http://pymc-devs.github.io/pymc/">PYMC</a> (Bayesian statistical models and fitting algorithms, including Markov chain Monte Carlo)</li>
+<li><a href="http://blog.fperez.org">Fernando Perez</a>: Lead developer of <a href="www.ipython.org">IPython</a>, great advocate of <a href="http://en.wikipedia.org/wiki/Open_science">open science</a> and reproducible research</li>
+<li>Brian Granger: Lead developer of the <a href="http://ipython.org/notebook.html">IPython notebook</a></li>
+<li><a href="http://blog.wesmckinney.com">Wes McKinney</a>: Lead developer of Pandas, author of <a href="http://shop.oreilly.com/product/0636920023784.do">Python for Data Analysis</a></li>
+<li><a href="http://biostat.mc.vanderbilt.edu/wiki/Main/ChrisFonnesbeck">Christopher Fonnesbeck</a>: developer of <a href="http://pymc-devs.github.io/pymc/">PYMC</a> (Bayesian statistical models and fitting algorithms, including Markov chain Monte Carlo)</li>
 <li><a href="http://www.astro.washington.edu/users/vanderplas/">Jake VanderPlas</a>: Astronomer, contributor to <a href="http://scikit-learn.org">scikit-learn</a></li>
 <li><a href="http://gael-varoquaux.info">Gaël Varoquaux</a>: One of the main contributors to <a href="http://scikit-learn.org">scikit-learn</a></li>
 <li><a href="http://ogrisel.com">Olivier Grisel</a>: Also main contributor to <a href="http://scikit-learn.org">scikit-learn</a></li>
-<li><a href="http://technicaldiscovery.blogspot.co.nz">Travis Oliphant</a>: One of the lead developpers of Numpy / Scipy, and founder of <a href="http://continuum.io">Continuum Analytics</a>.</li>
+<li><a href="http://technicaldiscovery.blogspot.co.nz">Travis Oliphant</a>: One of the lead developers of Numpy / Scipy, and founder of <a href="http://continuum.io">Continuum Analytics</a>.</li>
 <li>J.R. Johansson <a href="http://dml.riken.jp/~rob/">http://dml.riken.jp/~rob/</a></li>
-<li><a href="http://twiecki.github.io/">Thomas Wiecki</a>: developper of <a href="https://github.com/pymc-devs/pymc">PYMC3</a>, a fork of PYMC. </li>
-<li><a href="http://jseabold.net/">Skipper Seabold</a>: The main developper of <a href="http://statsmodels.sourceforge.net/">statsmodels</a></li>
+<li><a href="http://twiecki.github.io/">Thomas Wiecki</a>: developer of <a href="https://github.com/pymc-devs/pymc">PYMC3</a>, a fork of PYMC. </li>
+<li><a href="http://jseabold.net/">Skipper Seabold</a>: The main developer of <a href="http://statsmodels.sourceforge.net/">statsmodels</a></li>
 <li><a href="http://www.kevinsheppard.com/wiki/Main_Page">Kevin Sheppard</a> from University of Oxford: author or the book <a href="http://www.kevinsheppard.com/images/0/09/Python_introduction.pdf">Introduction to Python for Econometrics, Statistics and Numerical Analysis: Second Edition</a>. </li>
 </ul>
-<p>And finally <a href="http://blog.fperez.org/2013/07/in-memoriam-john-d-hunter-iii-1968-2012.html">John Hunter</a>, He was the founder and lead developper of <a href="http://matplotlib.org">Matplotlib</a>, a pivotal library to make Python a viable free and open-source alternative to commercial scientific software, and very sadly passed away in 2012.</p>
+<p>And finally <a href="http://blog.fperez.org/2013/07/in-memoriam-john-d-hunter-iii-1968-2012.html">John Hunter</a>, He was the founder and lead developer of <a href="http://matplotlib.org">Matplotlib</a>, a pivotal library to make Python a viable free and open-source alternative to commercial scientific software, and very sadly passed away in 2012.</p>
 <p>I encourage you - if you carry on using Python for science - to look up these people on google, have a look at their github repositories and the projects they contribute to, and follow them on twitter, some of them (<em>e.g.</em> Jake VanderPlas) have also very informative blogs. You can also donate to the <a href="http://numfocus.org/johnhunter.html">John Hunter memorial fund</a> as a way to give back to an important contributor to the Python scientific community.</p>
 <hr>
 
@@ -918,10 +880,10 @@ $(function() {
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[3]:</div>
+<div class="prompt input_prompt">In&nbsp;[4]:</div>
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span class="o">!</span>ipython nbconvert ressources.ipynb --to html
+<div class=" highlight hl-ipython2"><pre><span class="o">!</span>ipython nbconvert resources.ipynb --to html
 </pre></div>
 
 </div>
@@ -934,25 +896,12 @@ $(function() {
 
 <div class="output_area"><div class="prompt"></div>
 <div class="output_subarea output_stream output_stdout output_text">
-<pre>[NbConvertApp] Converting notebook ressources.ipynb to html
-[NbConvertApp] Writing 228219 bytes to ressources.html
+<pre>[NbConvertApp] Converting notebook resources.ipynb to html
+[NbConvertApp] Writing 229088 bytes to resources.html
 </pre>
 </div>
 </div>
 
-</div>
-</div>
-
-</div>
-<div class="cell border-box-sizing code_cell rendered">
-<div class="input">
-<div class="prompt input_prompt">In&nbsp;[&nbsp;]:</div>
-<div class="inner_cell">
-    <div class="input_area">
-<div class=" highlight hl-ipython2"><pre> 
-</pre></div>
-
-</div>
 </div>
 </div>
 

--- a/session_1/notebooks/resources.ipynb
+++ b/session_1/notebooks/resources.ipynb
@@ -101,7 +101,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# ressources"
+    "# resources"
    ]
   },
   {
@@ -202,7 +202,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "+ [www.google.com](www.google.com)\n",
+    "+ [www.google.com](http://www.google.com)\n",
     "+ [A good tutorial by Alan Gauld](http://www.freenetpages.co.uk/hp/alan.gauld/tutclass.htm)\n",
     "+ The [classes](http://docs.python.org/2/tutorial/classes.html) entry from the official Python doc \n",
     "+ A short [pdf](http://www1.gly.bris.ac.uk/~walker/PythonEarthSci/PfES_3.pdf) from Andrew Walker's [Python for Earth Scientists](http://www1.gly.bris.ac.uk/~walker/PythonEarthSci/) course\n"
@@ -325,7 +325,7 @@
     "+ [github repository for the above](https://github.com/barbagroup/CFDPython)\n",
     "+ [Python bindings to OpenFOAM](http://openfoamwiki.net/index.php/Contrib_PyFoam)\n",
     "+ [FiPy: A Finite Volume PDE Solver Using Python](http://matforge.org/fipy/)\n",
-    "+ [\"Practical Numerical Methods with Python\" MOOC]()"
+    "+ [\"Practical Numerical Methods with Python\" MOOC](http://openedx.seas.gwu.edu/courses/GW/MAE6286/2014_fall/about)"
    ]
   },
   {
@@ -430,7 +430,7 @@
     "+ [A gallery of interesting IPython Notebooks](https://github.com/ipython/ipython/wiki/A-gallery-of-interesting-IPython-Notebooks)\n",
     "\"...a curated collection of IPython notebooks that are notable for some reason.\"\n",
     "\n",
-    "+ [Scikit-learn tutorial](https://github.com/jakevdp/sklearn_scipy2013): Files and other info associated with the Scipy 2013 scikit-learn tutorial developped by Gaël Varoquaux, Olivier Grisel and Jake VanderPlas.\n",
+    "+ [Scikit-learn tutorial](https://github.com/jakevdp/sklearn_scipy2013): Files and other info associated with the Scipy 2013 scikit-learn tutorial developed by Gaël Varoquaux, Olivier Grisel and Jake VanderPlas.\n",
     "\n",
     "+ [Statistical Analysis tutorial](https://github.com/fonnesbeck/statistical-analysis-python-tutorial) from Chris. Fonnesbeck. \n",
     "\n",
@@ -538,20 +538,20 @@
    "source": [
     "In building this material, I have liberally '*borrowed*' from lecture notes, online notebooks, video recording of talks, code examples, articles, etc, that are freely available online, I would like to acknowledge in particular (list not exhaustive and in no particular order): \n",
     "\n",
-    "+ [Fernando Perez](http://blog.fperez.org): Lead developper of [IPython](www.ipython.org), great advocate of [open science](http://en.wikipedia.org/wiki/Open_science) and reproducible research\n",
-    "+ Brian Granger: Lead developper of the [IPython notebook](http://ipython.org/notebook.html)\n",
-    "+ [Wes McKinney](http://blog.wesmckinney.com): Lead developper of Pandas, author of [Python for Data Analysis](http://shop.oreilly.com/product/0636920023784.do)\n",
-    "+ [Christopher Fonnesbeck](http://biostat.mc.vanderbilt.edu/wiki/Main/ChrisFonnesbeck): Developper of [PYMC](http://pymc-devs.github.io/pymc/) (Bayesian statistical models and fitting algorithms, including Markov chain Monte Carlo)\n",
+    "+ [Fernando Perez](http://blog.fperez.org): Lead developer of [IPython](www.ipython.org), great advocate of [open science](http://en.wikipedia.org/wiki/Open_science) and reproducible research\n",
+    "+ Brian Granger: Lead developer of the [IPython notebook](http://ipython.org/notebook.html)\n",
+    "+ [Wes McKinney](http://blog.wesmckinney.com): Lead developer of Pandas, author of [Python for Data Analysis](http://shop.oreilly.com/product/0636920023784.do)\n",
+    "+ [Christopher Fonnesbeck](http://biostat.mc.vanderbilt.edu/wiki/Main/ChrisFonnesbeck): developer of [PYMC](http://pymc-devs.github.io/pymc/) (Bayesian statistical models and fitting algorithms, including Markov chain Monte Carlo)\n",
     "+ [Jake VanderPlas](http://www.astro.washington.edu/users/vanderplas/): Astronomer, contributor to [scikit-learn](http://scikit-learn.org)\n",
     "+ [Gaël Varoquaux](http://gael-varoquaux.info): One of the main contributors to [scikit-learn](http://scikit-learn.org)\n",
     "+ [Olivier Grisel](http://ogrisel.com): Also main contributor to [scikit-learn](http://scikit-learn.org)\n",
-    "+ [Travis Oliphant](http://technicaldiscovery.blogspot.co.nz): One of the lead developpers of Numpy / Scipy, and founder of [Continuum Analytics](http://continuum.io).\n",
+    "+ [Travis Oliphant](http://technicaldiscovery.blogspot.co.nz): One of the lead developers of Numpy / Scipy, and founder of [Continuum Analytics](http://continuum.io).\n",
     "+ J.R. Johansson http://dml.riken.jp/~rob/\n",
-    "+ [Thomas Wiecki](http://twiecki.github.io/): developper of [PYMC3](https://github.com/pymc-devs/pymc), a fork of PYMC. \n",
-    "+ [Skipper Seabold](http://jseabold.net/): The main developper of [statsmodels](http://statsmodels.sourceforge.net/)\n",
+    "+ [Thomas Wiecki](http://twiecki.github.io/): developer of [PYMC3](https://github.com/pymc-devs/pymc), a fork of PYMC. \n",
+    "+ [Skipper Seabold](http://jseabold.net/): The main developer of [statsmodels](http://statsmodels.sourceforge.net/)\n",
     "+ [Kevin Sheppard](http://www.kevinsheppard.com/wiki/Main_Page) from University of Oxford: author or the book [Introduction to Python for Econometrics, Statistics and Numerical Analysis: Second Edition](http://www.kevinsheppard.com/images/0/09/Python_introduction.pdf). \n",
     "\n",
-    "And finally [John Hunter](http://blog.fperez.org/2013/07/in-memoriam-john-d-hunter-iii-1968-2012.html), He was the founder and lead developper of [Matplotlib](http://matplotlib.org), a pivotal library to make Python a viable free and open-source alternative to commercial scientific software, and very sadly passed away in 2012.\n",
+    "And finally [John Hunter](http://blog.fperez.org/2013/07/in-memoriam-john-d-hunter-iii-1968-2012.html), He was the founder and lead developer of [Matplotlib](http://matplotlib.org), a pivotal library to make Python a viable free and open-source alternative to commercial scientific software, and very sadly passed away in 2012.\n",
     "\n",
     "I encourage you - if you carry on using Python for science - to look up these people on google, have a look at their github repositories and the projects they contribute to, and follow them on twitter, some of them (*e.g.* Jake VanderPlas) have also very informative blogs. You can also donate to the [John Hunter memorial fund](http://numfocus.org/johnhunter.html) as a way to give back to an important contributor to the Python scientific community.\n",
     "\n",
@@ -578,13 +578,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[NbConvertApp] Converting notebook ressources.ipynb to html\n",
-      "[NbConvertApp] Writing 229088 bytes to ressources.html\n"
+      "[NbConvertApp] Converting notebook resources.ipynb to html\n",
+      "[NbConvertApp] Writing 229088 bytes to resources.html\n"
      ]
     }
    ],
    "source": [
-    "!ipython nbconvert ressources.ipynb --to html"
+    "!ipython nbconvert resources.ipynb --to html"
    ]
   }
  ],


### PR DESCRIPTION
This pull request contains a few typos, and two missing/wrong URL's. Some iframes weren't working locally, but worked after adding some code to import the HTML function.

I used IPython notebooks only a few times, so please feel free to discard this pull request in case it included for than what was necessary, or if there's anything missing.

Will continue reading the rest of the content tomorrow. 

Many thanks!
Bruno
